### PR TITLE
Add category filtering legend

### DIFF
--- a/android_planner/README.md
+++ b/android_planner/README.md
@@ -40,5 +40,5 @@ launch.
 ## Status
 
 This is a skeleton implementation intended as a starting point.  Some
-features from the desktop version (legend filtering, yearly calendar,
-import/export) are not yet implemented.
+features from the desktop version (yearly calendar and import/export)
+are not yet implemented.

--- a/android_planner/app/views/legend.py
+++ b/android_planner/app/views/legend.py
@@ -1,0 +1,44 @@
+"""Legend view displaying category chips for filtering schedule."""
+from __future__ import annotations
+
+from typing import Optional
+
+from kivy.app import App
+from kivy.metrics import dp
+from kivymd.uix.boxlayout import MDBoxLayout
+from kivymd.uix.chip import MDChip
+
+from app import models
+
+
+class Legend(MDBoxLayout):
+    """Row of chips allowing the user to filter activities by category."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.orientation = "horizontal"
+        self.spacing = dp(8)
+        self._build_chips()
+
+    def _build_chips(self) -> None:
+        """Create one chip per category plus a *clear* chip."""
+        for category, color in models.CATEGORY_COLORS.items():
+            chip = MDChip(
+                text=category.capitalize(),
+                md_bg_color=self._hex_to_rgba(color),
+                on_release=lambda chip, c=category: self._on_chip(c),
+            )
+            self.add_widget(chip)
+        self.add_widget(
+            MDChip(text="Clear Filter", on_release=lambda *_: self._on_chip(None))
+        )
+
+    def _on_chip(self, category: Optional[str]) -> None:
+        """Notify the app about a new filter selection."""
+        app = App.get_running_app()
+        app.set_filter(category)
+
+    @staticmethod
+    def _hex_to_rgba(hex_color: str):
+        """Convert a ``#RRGGBB`` colour string to an RGBA tuple."""
+        return tuple(int(hex_color[i : i + 2], 16) / 255 for i in (1, 3, 5)) + (1.0,)

--- a/android_planner/main.py
+++ b/android_planner/main.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from kivy.lang import Builder
 from kivymd.app import MDApp
@@ -30,6 +30,7 @@ class PlannerApp(MDApp):
         super().__init__(**kwargs)
         self.data: Dict[str, Any] = {}
         self.title_text = "4-On / 4-Off Planner"
+        self.active_category: Optional[str] = None
 
     def build(self):
         Builder.load_file(Path(__file__).with_name("planner.kv"))
@@ -59,6 +60,11 @@ class PlannerApp(MDApp):
         for day, info in sorted(schedule.items(), key=lambda item: int(item[0])):
             tab = DayTab(day_key=str(day), title=info.get("title", f"Day {day}"))
             rv = tab.ids.rv
+            activities = [
+                act
+                for act in info.get("activities", [])
+                if not self.active_category or act[2] == self.active_category
+            ]
             rv.data = [
                 {
                     "time": act[0],
@@ -67,7 +73,7 @@ class PlannerApp(MDApp):
                     "day_key": str(day),
                     "index": idx,
                 }
-                for idx, act in enumerate(info.get("activities", []))
+                for idx, act in enumerate(activities)
             ]
             tabs.add_widget(tab)
 
@@ -115,6 +121,11 @@ class PlannerApp(MDApp):
 
     def toggle_theme(self):
         self.theme_cls.theme_style = "Dark" if self.theme_cls.theme_style == "Light" else "Light"
+
+    def set_filter(self, category: Optional[str]) -> None:
+        """Set the active category filter and refresh the schedule views."""
+        self.active_category = category
+        self.populate_tabs()
 
     # ------------------------------------------------------------------
     # Cycle calculation

--- a/android_planner/planner.kv
+++ b/android_planner/planner.kv
@@ -1,6 +1,7 @@
 #:import DayTab app.views.tabs.DayTab
 #:import CATEGORY_COLORS app.models.CATEGORY_COLORS
 #:import ActivityDialogContent app.views.dialogs.ActivityDialogContent
+#:import Legend app.views.legend.Legend
 
 <MainScreen@MDBoxLayout>:
     id: main_screen
@@ -29,6 +30,10 @@
         readonly: True
         size_hint_y: None
         height: dp(120)
+    Legend:
+        id: legend
+        size_hint_y: None
+        height: dp(48)
     MDTabs:
         id: tabs
     MDLabel:


### PR DESCRIPTION
## Summary
- add Legend view with category chips to filter schedule
- support category filtering in tab population
- document remaining features in README

## Testing
- `find . -name '*.py' -print0 | xargs -0 python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_68b1b0bcd0708328b52a98a54d7bb70f